### PR TITLE
grus: Drop some Prebuilt Packages

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -37,6 +37,10 @@ DEVICE_PACKAGE_OVERLAYS += \
 PRODUCT_COPY_FILES += \
     $(call find-copy-subdir-files,*,$(LOCAL_PATH)/qdcm/,$(TARGET_COPY_OUT_VENDOR)/etc)
 
+# Remove unwanted packages
+PRODUCT_PACKAGES += \
+    RemovePackages
+
 # Sensors
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/sensors/hals.conf:$(TARGET_COPY_OUT_VENDOR)/etc/sensors/hals.conf

--- a/remove_packages/Android.mk
+++ b/remove_packages/Android.mk
@@ -1,0 +1,34 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := RemovePackages
+LOCAL_MODULE_CLASS := APPS
+LOCAL_MODULE_TAGS := optional
+LOCAL_OVERRIDES_PACKAGES := AdaptiveVPNPrebuilt
+LOCAL_OVERRIDES_PACKAGES := Aperture AmbientSensePrebuilt YouTube Maps Drive
+LOCAL_OVERRIDES_PACKAGES += Photos
+LOCAL_OVERRIDES_PACKAGES += Chrome
+LOCAL_OVERRIDES_PACKAGES += Google
+LOCAL_OVERRIDES_PACKAGES += GoogleTTS
+LOCAL_OVERRIDES_PACKAGES += SafetyHubPrebuilt
+LOCAL_OVERRIDES_PACKAGES += PixelLiveWallpaperPrebuilt
+LOCAL_OVERRIDES_PACKAGES += Aperture AmbientStreaming
+LOCAL_OVERRIDES_PACKAGES += CalculatorGooglePrebuilt ExactCalculator
+LOCAL_OVERRIDES_PACKAGES += CalendarGooglePrebuilt Calendar2 Calendar
+LOCAL_OVERRIDES_PACKAGES += CarrierLocation CarrierMetrics
+LOCAL_OVERRIDES_PACKAGES += DevicePolicyPrebuilt
+LOCAL_OVERRIDES_PACKAGES += DiagnosticsToolPrebuilt
+LOCAL_OVERRIDES_PACKAGES += HealthConnectPrebuilt
+LOCAL_OVERRIDES_PACKAGES += NgaResources
+LOCAL_OVERRIDES_PACKAGES += Gallery2 Photos PhotoTable
+LOCAL_OVERRIDES_PACKAGES += Papers PixelLiveWallpaperPrebuilt
+LOCAL_OVERRIDES_PACKAGES += PixelWallpapers2020 PixelWallpapers2021 PixelWallpapers2022 PixelWallpapers2022a PixelWallpapers2023Tablet
+LOCAL_OVERRIDES_PACKAGES += RecorderPrebuilt
+LOCAL_OVERRIDES_PACKAGES += ScribePrebuilt Showcase
+LOCAL_OVERRIDES_PACKAGES += SecurityHubPrebuilt
+LOCAL_OVERRIDES_PACKAGES += SoundAmplifierPrebuilt
+LOCAL_OVERRIDES_PACKAGES += Tycho
+LOCAL_UNINSTALLABLE_MODULE := true
+LOCAL_CERTIFICATE := PRESIGNED
+LOCAL_SRC_FILES := /dev/null
+include $(BUILD_PREBUILT)


### PR DESCRIPTION
Our device has limited system partition size (legacy partition), so it's hard to ship heavy Gapps rom with all Xiaomi parts, so better remove some prebuilt packages to avoid partition shortage errors.